### PR TITLE
python: Use int's instead of strings for key id's

### DIFF
--- a/include/pb-tools/pb-tools.h
+++ b/include/pb-tools/pb-tools.h
@@ -3,8 +3,8 @@
 
 #define PB_TOOLS_VERSION_MAJOR 1
 #define PB_TOOLS_VERSION_MINOR 0
-#define PB_TOOLS_VERSION_PATCH 0
-#define PB_TOOLS_VERSION_STRING "1.0.0"
+#define PB_TOOLS_VERSION_PATCH 1
+#define PB_TOOLS_VERSION_STRING "1.0.1"
 
 #define PB_EXPORT __attribute__((visibility("default")))
 

--- a/python/python_wrapper.c
+++ b/python/python_wrapper.c
@@ -248,24 +248,15 @@ static PyObject* slc_revoke_key(PyObject* self, PyObject* args, PyObject* kwds)
 {
     struct pb_session* session = (struct pb_session*)self;
     static char *kwlist[] = {"key_id", NULL};
-    const char* key = NULL;
-    char* end;
-    uint32_t key_id;
+    unsigned int key_id;
 
     int ret;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s", kwlist, &key)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "I", kwlist, &key_id)) {
         return NULL;
     }
 
     if (validate_pb_session(session) != 0) {
-        return NULL;
-    }
-
-    errno = 0;
-    key_id = strtoul(key, &end, 16);
-    if (key_id == 0 || errno == ERANGE || key != end || *end != '\0') {
-        PyErr_SetString(PyExc_ValueError, "Invalid Key ID");
         return NULL;
     }
 
@@ -325,7 +316,7 @@ static PyObject* slc_get_active_keys(PyObject* self, PyObject* Py_UNUSED(args))
     }
 
     for (int i = 0; i < key_count; i++) {
-        PyList_SET_ITEM(keylist, i, PyUnicode_FromFormat("0x%x", active_keys[i]));
+        PyList_SET_ITEM(keylist, i, PyLong_FromLong(active_keys[i]));
     }
 
     return keylist;
@@ -361,7 +352,7 @@ static PyObject* slc_get_revoked_keys(PyObject* self, PyObject* Py_UNUSED(args))
     }
 
     for (int i = 0; i < key_count; i++) {
-        PyList_SET_ITEM(keylist, i, PyUnicode_FromFormat("0x%x", revoked_keys[i]));
+        PyList_SET_ITEM(keylist, i, PyLong_FromLong(revoked_keys[i]));
     }
 
     return keylist;

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ from setuptools import Extension
 import re
 
 setup(name='punchboot',
-      version="1.0.0",
+      version="1.0.1",
       description="Punchboot tools python wrapper",
       author="Jonas Blixt",
       author_email="jonpe960@gmail.com",


### PR DESCRIPTION
This changes the argument type and return values for:
 - slc_revoke_key
 - slc_get_active_keys
 - slc_get_revoked_keys

Both 'slc_get_active_keys' and 'slc_get_revoked_keys' now return a list of integers.

'slc_revoke_key' Now only accepts an integer as key_id argument.