### PR TITLE
python: Reset board response buffer

### DIFF
--- a/include/pb-tools/pb-tools.h
+++ b/include/pb-tools/pb-tools.h
@@ -3,8 +3,8 @@
 
 #define PB_TOOLS_VERSION_MAJOR 1
 #define PB_TOOLS_VERSION_MINOR 0
-#define PB_TOOLS_VERSION_PATCH 1
-#define PB_TOOLS_VERSION_STRING "1.0.1"
+#define PB_TOOLS_VERSION_PATCH 2
+#define PB_TOOLS_VERSION_STRING "1.0.2"
 
 #define PB_EXPORT __attribute__((visibility("default")))
 

--- a/python/python_wrapper.c
+++ b/python/python_wrapper.c
@@ -801,6 +801,8 @@ static PyObject* board_run_command(PyObject *self, PyObject* args, PyObject* kwd
 
     cmd_enc = pb_crc32(0, (unsigned char*)cmd, strlen(cmd));
 
+    memset(response, 0, sizeof(response));
+
     ret = pb_api_board_command(session->ctx, cmd_enc, cmd_args, cmd_args_len,
                                 response, sizeof(response));
     if (ret != PB_RESULT_OK) {


### PR DESCRIPTION
The command 'response' buffer may contain uninitialized data which in turn can cause the 'Py_BuildValue' to raise a 'UnicodeError'.

This commit ensures that the response buffer is zeroed out before the call to Py_BuildValue.